### PR TITLE
fix(users): 暂时关闭reCAPTCHA验证

### DIFF
--- a/src/routes/users.ts
+++ b/src/routes/users.ts
@@ -3,7 +3,7 @@ import express from "express";
 import jwt from "jsonwebtoken";
 import Email from "../models/email";
 import User from "../models/user";
-import recaptcha from "../middlewares/recaptcha";
+// import recaptcha from "../middlewares/recaptcha";
 import { sendEmail } from "../helpers/email";
 import {
   verifyEmailTemplate,
@@ -54,7 +54,8 @@ router.put("/delete", async(req, res) => {
   }
 })
 
-router.post("/", recaptcha, async (req, res) => {
+// router.post("/", recaptcha, async (req, res) => {
+router.post("/", async (req, res) => {
   const { email, password } = req.body;
 
   if (!email || !password) {
@@ -209,7 +210,7 @@ router.post("/verify", async (req, res) => {
   const { action, type } = req.body;
 
   if (action === "request") {
-    await new Promise((resolve) => recaptcha(req, res, resolve));
+    // await new Promise((resolve) => recaptcha(req, res, resolve));
 
     if (type === "regular") {
       const { email } = req.body;
@@ -378,7 +379,7 @@ router.post("/reset", async (req, res) => {
   const { action } = req.body;
 
   if (action === "request") {
-    await new Promise((resolve) => recaptcha(req, res, resolve));
+    // await new Promise((resolve) => recaptcha(req, res, resolve));
 
     const { email } = req.body;
 


### PR DESCRIPTION
很奇怪，校园网下reCAPTCHA验证框显示不出来，网络错误。
挂梯子后可以使用，有的换成手机热点也可以使用（但有的好像又不行）。
新生导师阶段有许多人要注册验证，为了方便暂时关闭reCAPTCHA。