### PR TITLE
feat(arena): suboptimal arena, crash status & envoy support

### DIFF
--- a/src/helpers/docker_queue.ts
+++ b/src/helpers/docker_queue.ts
@@ -8,7 +8,6 @@ import * as fs_promises from "fs/promises"
 import * as hasura from "./hasura";
 import * as utils from "./utils";
 import yaml from "js-yaml";
-import { typeOf } from "mathjs";
 
 export interface queue_element {
   contest_id: string;

--- a/src/helpers/docker_queue.ts
+++ b/src/helpers/docker_queue.ts
@@ -24,9 +24,9 @@ const get_port = async () => {
   const max_port_num = parseInt(process.env.MAX_PORTS! as string);
   const start_port = 8888;
   const ports_list = await hasura.get_exposed_ports();
-  for (var i = 0; i < max_port_num; i++) {
+  for (let i = 0; i < max_port_num; i++) {
     const result = start_port + i;
-    var flag = false;
+    let flag = false;
     for (const port_info of ports_list) {
       if (port_info.port === result) {
         flag = true;

--- a/src/helpers/hasura.ts
+++ b/src/helpers/hasura.ts
@@ -342,6 +342,23 @@ export const count_room_team: any = async (contest_id: string, team_id: string) 
   return count_room_from_team.contest_room_team_aggregate.aggregate.count;
 }
 
+export const get_exposed_ports: any = async () => {
+  const query_exposed_ports = await client.request(
+    gql`
+      query get_exposed_ports {
+        contest_room(where: {status: {_eq: "Running"}}) {
+          port
+          room_id
+        }
+      }
+    `
+  );
+  console.log("hasura result: " );
+  console.log(query_exposed_ports)
+  const result = query_exposed_ports.contest_room
+  return result;
+}
+
 /**
  * query player_label from contest_id and team_label
  * @param {string} contest_id

--- a/src/helpers/hasura.ts
+++ b/src/helpers/hasura.ts
@@ -279,6 +279,70 @@ export const get_maneger_from_user: any = async (user_uuid: string, contest_id: 
   return query_if_manager.contest_manager[0]?.user_uuid ?? null;
 }
 
+/**
+ * get max game time from contest_id in seconds
+ * @param {string} contest_id
+ * @returns {number} game time
+ */
+export const get_max_game_time: any = async (contest_id: string) => {
+  const max_game_time = await client.request(
+    gql`
+      query get_max_game_time($contest_id: uuid!) {
+        contest(where: {id: {_eq: $contest_id}}) {
+          max_game_time
+        }
+      }
+    `,
+    {
+      contest_id: contest_id,
+    }
+  );
+  console.log(max_game_time);
+  return max_game_time.contest[0].max_game_time ?? null;
+}
+
+
+/**
+ * get server docker memory limit from contest_id (in GB)
+ * @param {string} contest_id
+ * @returns {number} server memory limit (GB)
+ */
+export const get_server_memory_limit: any = async (contest_id: string) => {
+  const server_memory_limit = await client.request(
+    gql`
+      query get_server_memory_limit($contest_id: uuid!) {
+        contest(where: {id: {_eq: $contest_id}}) {
+          server_memory_limit
+        }
+      }
+    `,
+    {
+      contest_id: contest_id,
+    }
+  );
+  return server_memory_limit.contest[0].server_memory_limit ?? null;
+}
+
+/**
+ * get client docker memory limit from contest_id (in GB)
+ * @param {string} contest_id
+ * @returns {number} client memory limit (GB)
+ */
+export const get_client_memory_limit: any = async (contest_id: string) => {
+  const client_memory_limit = await client.request(
+    gql`
+      query get_client_memory_limit($contest_id: uuid!) {
+        contest(where: {id: {_eq: $contest_id}}) {
+          client_memory_limit
+        }
+      }
+    `,
+    {
+      contest_id: contest_id,
+    }
+  );
+  return client_memory_limit.contest[0].client_memory_limit ?? null;
+}
 
 /**
  * query language and contest_id from code_id

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -46,7 +46,7 @@ export interface TeamLabelBind {
   label: string;
 }
 
-export interface ContestScores { // used by server docker.
+export interface ContestResult { // used by server docker.
   status: string; // value: `Finished` or `Crashed`.
   scores: number[]; // order is the same as `team_label_binds`.
 };

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -140,6 +140,9 @@ export async function uploadObject(localFilePath: string, bucketKey: string, cos
         console.log(err);
         reject('Failed to upload object to COS');
       } else {
+        if (data) {
+          console.debug('Upload Success');
+        }
         // console.debug('Upload Success', data);
         resolve(true);
       }

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -140,7 +140,7 @@ export async function uploadObject(localFilePath: string, bucketKey: string, cos
         console.log(err);
         reject('Failed to upload object to COS');
       } else {
-        console.debug('Upload Success', data);
+        // console.debug('Upload Success', data);
         resolve(true);
       }
     });

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -46,7 +46,12 @@ export interface TeamLabelBind {
   label: string;
 }
 
-export interface ContestResult {
+export interface ContestScores { // used by server docker.
+  status: string; // value: `Finished` or `Crashed`.
+  scores: number[]; // order is the same as `team_label_binds`.
+};
+
+export interface TeamResult { // used by backend.
   team_id: string;
   score: number;
 };

--- a/src/routes/arena.ts
+++ b/src/routes/arena.ts
@@ -458,7 +458,7 @@ router.post("/finish", async (req, res) => {
           console.log("Files uploaded!")
 
         } catch (err) {
-          return res.status(500).send("500 Internal Server Error: Delete files failed. " + err);
+          return res.status(500).send("500 Internal Server Error: Upload files failed. " + err);
         }
 
       } catch (err) {

--- a/src/routes/arena.ts
+++ b/src/routes/arena.ts
@@ -460,7 +460,6 @@ router.post("/finish", async (req, res) => {
               });
           });
           const upload_file = await Promise.all(upload_file_promises);
-          console.debug("upload_file: ", upload_file);
           if (upload_file.some(result => !result)) {
             return res.status(500).send("500 Internal Server Error: File upload failed");
           }

--- a/src/routes/arena.ts
+++ b/src/routes/arena.ts
@@ -415,7 +415,7 @@ router.post("/finish", async (req, res) => {
           hasura.update_room_team_score(room_id, team_id, update_scores[index]));
         await Promise.all(update_room_team_score_promises);
 
-        await hasura.update_room_status(room_id, "Finished", null);
+        await hasura.update_room_status(room_id, "Finished");
         console.log("Update room team score!")
 
         const origin_result: utils.TeamResult[] = await hasura.get_teams_score(team_ids);
@@ -435,7 +435,7 @@ router.post("/finish", async (req, res) => {
         console.log("Update team score!")
       } else if (game_status === 'Crashed') {
         // no need to update score
-        await hasura.update_room_status(room_id, "Crashed", null);
+        await hasura.update_room_status(room_id, "Crashed");
       }
 
       const base_directory = await utils.get_base_directory();

--- a/src/routes/arena.ts
+++ b/src/routes/arena.ts
@@ -379,7 +379,7 @@ router.post("/get-score", async (req, res) => {
 
 /**
  * @param token
- * @param {utils.ContestScores} result
+ * @param {utils.ContestResult} result
  */
 router.post("/finish", async (req, res) => {
   try {

--- a/src/routes/competition.ts
+++ b/src/routes/competition.ts
@@ -699,7 +699,7 @@ router.post("/finish-one", async (req, res) => {
           hasura.update_room_team_score(room_id, team_id, update_scores[index]));
         await Promise.all(update_room_team_score_promises);
 
-        await hasura.update_room_status(room_id, "Finished", null);
+        await hasura.update_room_status(room_id, "Finished");
         console.log("Update room team score!")
 
         const origin_result: utils.TeamResult[] = await hasura.get_teams_contest_score(team_ids);
@@ -719,7 +719,7 @@ router.post("/finish-one", async (req, res) => {
         console.log("Update team score!")
       } else if (game_status === 'Crashed') {
         // no need to update score
-        await hasura.update_room_status(room_id, "Crashed", null);
+        await hasura.update_room_status(room_id, "Crashed");
       }
 
 

--- a/src/routes/competition.ts
+++ b/src/routes/competition.ts
@@ -663,7 +663,7 @@ router.post("/get-score", async (req, res) => {
 
 /**
  * @param token
- * @param {utils.ContestScores} result
+ * @param {utils.ContestResult} result
  */
 router.post("/finish-one", async (req, res) => {
   try {


### PR DESCRIPTION
修正房间端口和状态分配规则以支持高并发的天梯请求。room status 的更新与 port 的更新过程分离。端口的占用和释放均由 Envoy 负责。总体流程：占用 port -> 更新 status Running -> 更新 status Finished/Crashed -> 释放 port，最大限度地避免 port 临界资源的冲突。

在 QUEUE_CHECK_TIME=20，MAX_PORT=3 条件下发送 8 个对战请求，结果如下，7/8 成功，1条 crash ，原因未知。考虑之后在 cos 附带上 crash report。

![image](https://github.com/eesast/api/assets/88619302/7d1dcdb7-84d6-44a6-a1ce-9d82d3c92a2a)

默认开放直播端口，无论 expose 多少都会申请端口。非直播情况尚未测试，可能会有明显的问题（例如端口无法释放）。